### PR TITLE
README Updated - Micropython for ESP8266

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ $ ampy put mpr121.py
 **Basic usage**
 
 ```python
+import machine
 import mpr121
+import time
 
-from machine import Pin
-i2c = machine.I2C(3)
-
+i2c = machine.I2C(-1, machine.Pin(14), machine.Pin(12))
 mpr = mpr121.MPR121(i2c, 0x5A)
 
 print(mpr.touched())


### PR DESCRIPTION
Hi There !

Thank's for the MPR121, it was not working for me, so I made few changes and it's working now !

i2c = machine.I2C(3) previous command returned error in mu-editor.

Quick research on the web and long iteration at home gave the following solution :

i2c = machine.I2C(-1, machine.Pin(14), machine.Pin(12)) 

Where machine.Pin(14) is the SCL GPIO, and machine.Pin(14) is the SDA GPIO for the I2C channel.

Best !